### PR TITLE
Embed Metadata and Format String

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,11 @@ name = "pypi"
 [packages]
 requests = "*"
 tabulate = "*"
+dicttoxml = "*"
+mutagen = "*"
 
 [dev-packages]
+flake8 = "*"
 
 [requires]
 python_version = "3.11"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ options:
   -i id, --info id      Print media info (JSON).
   -j, --json            Output verbose JSON instead of tables.
   -e, --embed-metadata  Embeds metadata in MP3 files, including chapter markers
+  -ofs string, --output-format-string string
+                        Format string specifying output folders.
+  -nrs, --no_replace_space
+                        Does not replace spaces in folder path with underscores.
+  
 </pre>
 
 Alternatively you can run PyLibby without pipenv, but make sure you have 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ options:
   -si, --save-info      Save information about downloaded book.
   -i id, --info id      Print media info (JSON).
   -j, --json            Output verbose JSON instead of tables.
+  -e, --embed-metadata  Embeds metadata in MP3 files, including chapter markers
 </pre>
 
 Alternatively you can run PyLibby without pipenv, but make sure you have 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ format string.  Substitutions include:
 %t - title
 %a - author
 %s - series
+%S - subtitle
 %v - volume (book in series)
 %p - publisher
 %y - year published
@@ -100,7 +101,7 @@ a series.  To do so, simply include:
 %s{/}
 
 Which will render to / if there is a series, but if the book is not in a series,
-will just disappear.
+will just disappear.  This similarly works on subtitle existence with %S
 
 By default, the output folder for a book will have spaces replaced with
 underscores.  To prevent this, simply add -nrs to the command line.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,40 @@ For audiobooks the format will always be "audiobook-mp3".
 ```bash
 python pylibby.py -dl 654321 -f audiobook-mp3 -o /home/username/books
 ```
+
+When downloading an book, you can specify the output format using a custom
+format string.  Substitutions include:
+
+%t - title
+%a - author
+%s - series
+%v - volume (book in series)
+%p - publisher
+%y - year published
+%n - narrator
+%i - isbn
+%o - ODID
+
+Additionally, you can include text, but make it conditional on if the book is in
+a series.  To do so, simply include:
+
+%s{/}
+
+Which will render to / if there is a series, but if the book is not in a series,
+will just disappear.
+
+By default, the output folder for a book will have spaces replaced with
+underscores.  To prevent this, simply add -nrs to the command line.
+
+Thus, an example is:
+```bash
+python pylibby.py -dl 654321 -f audiobook-mp3 -ofs "%a/%t" -nrs
+```
+
+Which will result in a folder structure like:
+
+Jane Austen/Pride and Prejudice/file.mp3
+
 You can search for books like this:
 ```bash
 python pylibby.py -s "moby dick"

--- a/pylibby.py
+++ b/pylibby.py
@@ -245,7 +245,7 @@ class Libby:
             format_string = format_string.replace("%v", media_info['detailedSeries']['readingOrder'])
         else:
             format_string = re.sub(r"%s\{([^{}]*)\}", "", format_string)
-            format_string = format_string.replace("\%s", "")
+            format_string = format_string.replace("%s", "")
             format_string = format_string.replace("%v", "")
 
         if no_replace_space:

--- a/pylibby.py
+++ b/pylibby.py
@@ -218,15 +218,6 @@ class Libby:
     def get_download_path(self, media_info: dict, format_string="%a/%s %v-%t-[%y]-[ODID %o]-[ISBN %i]", no_replace_space=False) -> str:
         # this takes "%s{/}", and replaces it with "/", but only if the series
         # exists.  We do this to allow for creating subfolders, but only if there is a series.
-        print(format_string)
-        if "detailedSeries" in media_info:
-            format_string = re.sub(r"%s\{/(.*)\}", r"/\1", format_string)
-            format_string = format_string.replace("%s", media_info['detailedSeries']['seriesName'])
-            format_string = format_string.replace("%v", media_info['detailedSeries']['readingOrder'])
-        else:
-            format_string = re.sub(r"%s\{/(.*)\}", "", format_string)
-            format_string = format_string.replace("\%s", "")
-            format_string = format_string.replace("%v", "")
         format_string = format_string.replace("%a", self.get_author_by_media_info(media_info))
         format_string = format_string.replace("%t", media_info['title'])
         if "publishDate" in media_info:
@@ -236,11 +227,26 @@ class Libby:
         format_string = format_string.replace("%o", media_info['id'])
         format_string = format_string.replace("%p", media_info['publisher']['name'])
         format_string = format_string.replace("%n", self.get_narrator_by_media_info(media_info))
+        if "subtitle" in media_info:
+            format_string = re.sub(r"%S\{([^{}]*)\}", r"\1", format_string)
+            format_string = format_string.replace("%S", media_info["subtitle"])
+        else:
+            format_string = re.sub(r"%S\{([^{}]*)\}", format_string)
+            format_string = format_string.replace("%S", "")
 
         for f in media_info["formats"]:
             for i in f["identifiers"]:
                 if i["type"] == "ISBN":
                     format_string = format_string.replace("%i", i['value'])
+
+        if "detailedSeries" in media_info:
+            format_string = re.sub(r"%s\{([^{}]*)\}", r"\1", format_string)
+            format_string = format_string.replace("%s", media_info['detailedSeries']['seriesName'])
+            format_string = format_string.replace("%v", media_info['detailedSeries']['readingOrder'])
+        else:
+            format_string = re.sub(r"%s\{([^{}]*)\}", "", format_string)
+            format_string = format_string.replace("\%s", "")
+            format_string = format_string.replace("%v", "")
 
         if no_replace_space:
             print(format_string)

--- a/pylibby.py
+++ b/pylibby.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PyLibby. If not, see <http://www.gnu.org/licenses/>.
 
+import random
 import json
 import sys
 import urllib.parse
@@ -24,6 +25,7 @@ import requests
 import os
 import dicttoxml
 import html
+import time
 import re
 from mutagen.mp3 import MP3
 from mutagen.id3 import TXXX, TPE1, TIT2, TIT3, TPUB, TYER, TCOM, TCON, TALB, TDRL, COMM
@@ -299,8 +301,14 @@ class Libby:
                         else:
                             print(f"{filename}: Downloaded {mb}MB.")
             if embed_metadata:
-                self.embed_tag_data(os.path.join(final_path, filename), tocout[filename], audiobook_info)
-                print(f"Embedded tags in {filename}")
+                if filename in tocout:
+                    self.embed_tag_data(os.path.join(final_path, filename), tocout[filename], audiobook_info)
+                    print(f"Embedded tags in {filename}")
+                else:
+                    self.embed_tag_data(os.path.join(final_path, filename), "<Markers><Marker><Name>(continued)</Name><Time>0:00.000</Time></Marker></Markers>", audiobook_info)
+                    print("no toc to embed, generated (continued) chapter marker, and embedded it.")
+
+            time.sleep(random.random() * 2)
 
         if save_info:
             with open(os.path.join(final_path, "info.json"), "w") as w:
@@ -385,9 +393,9 @@ class Libby:
         return tocout
     
     def convert_seconds_to_timestamp(self, seconds: str) -> str:
-        minutes, secs = divmod(int(seconds), 60)
+        minutes, secs = divmod(float(seconds), 60)
 
-        timestamp = f"{minutes:02d}:{secs:02d}.000"
+        timestamp = f"{minutes:02.0f}:{secs:06.03f}"
         return timestamp
 
     def get_filename(self, url: str) -> str:

--- a/pylibby.py
+++ b/pylibby.py
@@ -343,8 +343,9 @@ class Libby:
                 if "detailedSeries" in audiobook_info["media_info"]:
                     series = TXXX(desc="MVNM",text=audiobook_info["media_info"]["detailedSeries"]["seriesName"])
                     tag.add(series)
-                    vol_number = TXXX(desc="MVIN",text=audiobook_info["media_info"]["detailedSeries"]["readingOrder"])
-                    tag.add(vol_number)
+                    if "readingOrder" in audiobook_info["media_info"]["detailedSeries"]:
+                        vol_number = TXXX(desc="MVIN",text=audiobook_info["media_info"]["detailedSeries"]["readingOrder"])
+                        tag.add(vol_number)
 
                 language = TXXX(desc="language", text=self.get_languages_by_media_info(audiobook_info["media_info"]))
                 tag.add(language)

--- a/pylibby.py
+++ b/pylibby.py
@@ -242,7 +242,12 @@ class Libby:
         if "detailedSeries" in media_info:
             format_string = re.sub(r"%s\{([^{}]*)\}", r"\1", format_string)
             format_string = format_string.replace("%s", media_info['detailedSeries']['seriesName'])
-            format_string = format_string.replace("%v", media_info['detailedSeries']['readingOrder'])
+            if "readingOrder" in media_info['detailedSeries']:
+                format_string = re.sub(r"%v\{([^{}]*)\}", r"\1", format_string)
+                format_string = format_string.replace("%v", media_info['detailedSeries']['readingOrder'])
+            else:
+                format_string = re.sub(r"%v\{([^{}]*)\}", "", format_string)
+                format_string = format_string.replace("%v", "")
         else:
             format_string = re.sub(r"%s\{([^{}]*)\}", "", format_string)
             format_string = format_string.replace("%s", "")

--- a/pylibby.py
+++ b/pylibby.py
@@ -231,7 +231,7 @@ class Libby:
             format_string = re.sub(r"%S\{([^{}]*)\}", r"\1", format_string)
             format_string = format_string.replace("%S", media_info["subtitle"])
         else:
-            format_string = re.sub(r"%S\{([^{}]*)\}", format_string)
+            format_string = re.sub(r"%S\{([^{}]*)\}", "", format_string)
             format_string = format_string.replace("%S", "")
 
         for f in media_info["formats"]:

--- a/pylibby.py
+++ b/pylibby.py
@@ -330,7 +330,7 @@ class Libby:
                 tag.add(year2)
                 narrator = TCOM(text=self.get_narrator_by_media_info(audiobook_info["media_info"],delim=","))
                 tag.add(narrator)
-                desc = COMM(lang='\x00\x00\x00', desc='', text=re.sub("<\\/?[BIbi]>","",html.unescape(audiobook_info["media_info"]["description"]).replace("<br>", "\n")))
+                desc = COMM(lang='\x00\x00\x00', desc='', text=re.sub("<\\/?[BIbiPp]>","",html.unescape(audiobook_info["media_info"]["description"]).replace("<br>", "\n")))
                 tag.add(desc)
                 genre = TCON(text=";".join(map(lambda x: x["name"], audiobook_info["media_info"]["subjects"])))
                 tag.add(genre)

--- a/pylibby.py
+++ b/pylibby.py
@@ -22,6 +22,11 @@ import sys
 import urllib.parse
 import requests
 import os
+import dicttoxml
+import html
+import re
+from mutagen.mp3 import MP3
+from mutagen.id3 import TXXX, TPE1, TIT2, TIT3, TPUB, TYER, TCOM, TCON, TALB, TDRL, COMM
 from typing import Callable
 from os import path
 import datetime
@@ -231,7 +236,7 @@ class Libby:
 
     def download_audiobook_mp3(self, loan: dict, output_path: str,
                                callback_functions: list[Callable[[str, int], None]] = None,
-                               save_info=False, download_covers=True):
+                               save_info=False, download_covers=True, embed_metadata=False):
         # Workaround for getting audiobook without ODM
         audiobook_info = self.open_audiobook(loan["cardId"], loan["id"])
         if not os.path.exists(output_path):
@@ -239,6 +244,10 @@ class Libby:
 
         final_path = os.path.join(output_path, self.get_download_path(audiobook_info["media_info"]))
         os.makedirs(final_path, exist_ok=True)
+
+        if embed_metadata:
+            tocout = self.get_toc_from_audiobook_info(audiobook_info)
+            print("Converted Chapter Markers to OverDrive Format")
 
         for download_url in \
                 [audiobook_info["audiobook_urls"]["urls"]["web"] + s["path"] for s in audiobook_info["openbook"]["spine"]]:
@@ -259,6 +268,9 @@ class Libby:
                                 f(filename, mb)
                         else:
                             print(f"{filename}: Downloaded {mb}MB.")
+            if embed_metadata:
+                self.embed_tag_data(os.path.join(final_path, filename), tocout[filename], audiobook_info)
+                print(f"Embedded tags in {filename}")
 
         if save_info:
             with open(os.path.join(final_path, "info.json"), "w") as w:
@@ -266,6 +278,86 @@ class Libby:
 
         if download_covers:
             self.download_covers(loan, final_path)
+
+    def embed_tag_data(self, filename: str, toc_entry_for_file: dict, audiobook_info: dict):
+                # open file for tag embedding
+                file = MP3(filename)
+                if file.tags is None:
+                    file.add_tags()
+                tag = file.tags
+
+                #create and add tags
+                artist = TPE1(text=",".join([a['name'] for a in audiobook_info["media_info"]["creators"] if a['role'] == "Author"]))
+                tag.add(artist)
+                title = TIT2(text=audiobook_info["media_info"]["title"])
+                title_album = TALB(text=audiobook_info["media_info"]["title"])
+                tag.add(title)
+                tag.add(title_album)
+                if "subtitle" in audiobook_info["media_info"]:
+                    subtitle = TIT3(text=audiobook_info["media_info"]["subtitle"])
+                    tag.add(subtitle)
+                publisher = TPUB(text=audiobook_info["media_info"]["publisher"]["name"])
+                tag.add(publisher)
+                # Year usage non-standardized, use both
+                year = TYER(text=str(datetime.datetime.fromisoformat(audiobook_info["media_info"]['publishDate']).year))
+                year2 = TDRL(text=datetime.datetime.fromisoformat(audiobook_info["media_info"]['publishDate']).strftime("%Y-%m-%d"))
+                tag.add(year)
+                tag.add(year2)
+                narrator = TCOM(text=",".join([a['name'] for a in audiobook_info["media_info"]["creators"] if a['role'] == "Narrator"]))
+                tag.add(narrator)
+                desc = COMM(lang='\x00\x00\x00', desc='', text=re.sub("<\\/?[BIbi]>","",html.unescape(audiobook_info["media_info"]["description"]).replace("<br>", "\n")))
+                tag.add(desc)
+                genre = TCON(text=";".join(map(lambda x: x["name"], audiobook_info["media_info"]["subjects"])))
+                tag.add(genre)
+                ## IF NOT SERIES
+                if "detailedSeries" in audiobook_info["media_info"]:
+                    series = TXXX(desc="MVNM",text=audiobook_info["media_info"]["detailedSeries"]["seriesName"])
+                    tag.add(series)
+                    vol_number = TXXX(desc="MVIN",text=audiobook_info["media_info"]["detailedSeries"]["readingOrder"])
+                    tag.add(vol_number)
+
+                language = TXXX(desc="language", text=",".join(map(lambda x: x['name'],audiobook_info["media_info"]["languages"])))
+                tag.add(language)
+
+                isbn = None
+                for f in audiobook_info["media_info"]["formats"]:
+                    for i in f["identifiers"]:
+                        if i["type"] == "ISBN":
+                            isbn = TXXX(desc="ISBN", text=i['value'])
+                if isbn is not None:
+                    tag.add(isbn)
+
+                chapters = TXXX(desc="OverDrive MediaMarkers", text=toc_entry_for_file)
+                tag.add(chapters)
+
+                # save
+                file.save()
+
+    def get_toc_from_audiobook_info(self, audiobook_info: dict) -> dict:
+        toc = {}
+        for entry in audiobook_info["openbook"]["nav"]["toc"]:
+            filename = entry["path"].split("}")[-1].split("#")[0]
+            if filename not in toc:
+                toc[filename] = []
+            new_entry = {}
+            new_entry["Name"] = entry["title"]
+            timestamp_temp = entry["path"].split("#")
+            new_entry["Time"] = self.convert_seconds_to_timestamp(timestamp_temp[-1]) if len(timestamp_temp) != 1 else "0:00.000"
+            toc[filename].append(new_entry)
+        tocout = {}
+        for key, value in toc.items():
+            tocout[key] = dicttoxml.dicttoxml(value, custom_root='Markers',
+                                              xml_declaration=False,
+                                              attr_type=False,
+                                              return_bytes=False,
+                                              item_func=lambda x: 'Marker')
+        return tocout
+    
+    def convert_seconds_to_timestamp(self, seconds: str) -> str:
+        minutes, secs = divmod(int(seconds), 60)
+
+        timestamp = f"{minutes:02d}:{secs:02d}.000"
+        return timestamp
 
     def get_filename(self, url: str) -> str:
         url_parsed = urllib.parse.unquote(url)
@@ -289,7 +381,7 @@ class Libby:
                 with open(os.path.join(path_, c + ".jpg"), "wb") as w:
                     w.write(self.http_session.get(media_info["covers"][c]["href"]).content)
 
-    def download_loan(self, loan: dict, format_id: str, output_path: str, save_info=False, download=True, download_covers=True, get_odm=False):
+    def download_loan(self, loan: dict, format_id: str, output_path: str, save_info=False, download=True, download_covers=True, get_odm=False, embed_metadata=False):
         # Does not actually download ebook, only gets the ODM or ACSM for now.
         # Will however download audiobook-mp3, without ODM
         if not os.path.exists(output_path):
@@ -313,7 +405,7 @@ class Libby:
                     else:
                         raise RuntimeError(f"Something went wrong when downloading odm: {fulfill}")
                 else:
-                    self.download_audiobook_mp3(loan, output_path, save_info=save_info)
+                    self.download_audiobook_mp3(loan, output_path, save_info=save_info, embed_metadata=embed_metadata)
             else:
                 #resp = self.http_session.get(url)
                 #print(resp)
@@ -381,6 +473,7 @@ if __name__ == "__main__":
     parser.add_argument("-si", "--save-info", help="Save information about downloaded book.", action="store_true")
     parser.add_argument("-i", "--info", help="Print media info (JSON).", type=str, metavar="id")
     parser.add_argument("-j", "--json", help="Output verbose JSON instead of tables.", action="store_true")
+    parser.add_argument("-e", "--embed-metadata", help="Embeds metadata in MP3 files, including chapter markers", action="store_true")
     args = parser.parse_args()
 
     L = Libby(args.id_file, code=args.code)
@@ -446,7 +539,7 @@ if __name__ == "__main__":
 
         elif arg in ["-dl", "--download"]:
             print("Downloading", sys.argv[arg_pos + 1])
-            L.download_loan(L.get_loan(sys.argv[arg_pos + 1]), args.format, args.output, args.save_info, get_odm=args.odm)
+            L.download_loan(L.get_loan(sys.argv[arg_pos + 1]), args.format, args.output, args.save_info, get_odm=args.odm, embed_metadata=args.embed_metadata)
 
         elif arg in ["-r", "--return-book"]:
             L.return_book(sys.argv[arg_pos + 1])


### PR DESCRIPTION
I really like your project, and have spent the last couple days adding some features that I think make it better.

Specifically, the MP3 files that are downloaded have no metadata in them.  I added the flag "-e", which embeds the metadata into the MP3 files.  This also embeds the chapter markers in OverDrive MediaMarker XML format, which is recognized by applications such as [audiobookshelf](https://github.com/advplyr/audiobookshelf).  

I have also added the feature to specify a format string for the output folders.  This should allow the user to specify the string however they want.  I left the way you had it as defaults, with the ability to override it.  As part of this, I included the flag "-nrs", which prevents the application from replacing spaces with underscores.

Let me know if you have any questions, suggestions, or revisions you want.