### PR TITLE
Provide a compat_datetime_fromisoformat for 3.11's datetime.fromisoformat

### DIFF
--- a/pylibby.py
+++ b/pylibby.py
@@ -38,6 +38,16 @@ from tabulate import tabulate
 VERSION = "0.3.2"
 
 
+def compat_datetime_fromisoformat(date_string):
+    """
+    Provide a compat alternative to 3.11's datetime.fromisoformat
+    """
+    try:
+        return datetime.datetime.fromisoformat(date_string)
+    except ValueError:
+        return datetime.datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
+
+
 class Libby:
     id_path = None
     archive = None
@@ -313,7 +323,7 @@ class Libby:
         format_string = format_string.replace("%a", self.get_author_by_media_info(media_info))
         format_string = format_string.replace("%t", media_info['title'])
         if "publishDate" in media_info:
-            format_string = format_string.replace("%y", str(datetime.datetime.fromisoformat(media_info['publishDate']).year))
+            format_string = format_string.replace("%y", str(compat_datetime_fromisoformat(media_info['publishDate']).year))
         else:
             # Removing the stuff people usually put around. Maybe we can find a regex for this? Order is important.
             # Maybe make "%y{%y - }" possible instead?
@@ -447,8 +457,8 @@ class Libby:
                 tag.add(publisher)
                 # Year usage non-standardized, use both
                 if "publishDate" in audiobook_info["media_info"]:
-                    year = TYER(text=str(datetime.datetime.fromisoformat(audiobook_info["media_info"]['publishDate']).year))
-                    year2 = TDRL(text=datetime.datetime.fromisoformat(audiobook_info["media_info"]['publishDate']).strftime("%Y-%m-%d"))
+                    year = TYER(text=str(compat_datetime_fromisoformat(audiobook_info["media_info"]['publishDate']).year))
+                    year2 = TDRL(text=compat_datetime_fromisoformat(audiobook_info["media_info"]['publishDate']).strftime("%Y-%m-%d"))
                     tag.add(year)
                     tag.add(year2)
                 narrator = TCOM(text=self.get_narrator_by_media_info(audiobook_info["media_info"],delim="/"))
@@ -501,7 +511,7 @@ class Libby:
                                               return_bytes=False,
                                               item_func=lambda x: 'Marker')
         return tocout
-    
+
     def convert_seconds_to_timestamp(self, seconds: str) -> str:
         minutes, secs = divmod(float(seconds), 60)
 


### PR DESCRIPTION
Adds a compat alternative to py 3.11's datetime.fromisoformat() so that it can run on older versions of py3 (example #11).

Tested on py 3.10.