### PR TITLE
Enable fromfile_prefix_chars for argparse

### DIFF
--- a/pylibby.py
+++ b/pylibby.py
@@ -795,7 +795,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog='PyLibby',
         description=f'CLI for Libby v{VERSION}',
-        formatter_class=argparse.RawTextHelpFormatter)
+        formatter_class=argparse.RawTextHelpFormatter,
+        fromfile_prefix_chars="@")
 
     parser.add_argument("-id", "--id-file", help="Path to id JSON (which you get from '--code'. Defaults to ./config/id.json).", default=os.getenv("ID", "./config/id.json"), metavar="path")
     parser.add_argument("-c", "--code", help="Login with code.", type=int, metavar="12345678", default=os.getenv("CODE"))


### PR DESCRIPTION
This allows the user to put frequently used options into a config file to save a bunch of typing.

Example:

```bash
python pylibby.py -dl XXXXXXX -f 'audiobook-mp3' --embed-metadata --replace-space --output=downloads/

# can be shortened to
python pylibby.py -dl XXXXXXX -f 'audiobook-mp3' @download.conf
```

where `download.conf` looks like
```
--embed-metadata
--replace-space
--output=downloads/
```